### PR TITLE
Updated rlang package in renv.lock

### DIFF
--- a/renv.lock
+++ b/renv.lock
@@ -1438,11 +1438,14 @@
     },
     "rlang": {
       "Package": "rlang",
-      "Version": "1.0.6",
+      "Version": "1.1.4",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "4ed1f8336c8d52c3e750adcdc57228a7",
-      "Requirements": []
+      "Requirements": [
+        "R",
+        "utils"
+      ],
+      "Hash": "3eec01f8b1dee337674b2e34ab1f9bc1"
     },
     "rmarkdown": {
       "Package": "rmarkdown",


### PR DESCRIPTION
A previous version of rlang (1.0.6) was installed and other packages are depending on 1.1.0 or greater shown by this error
![image](https://github.com/user-attachments/assets/b7bcde3a-aae5-4e89-af5d-20714f47ac71)
