### PR TITLE
Add feeds

### DIFF
--- a/_scripts/news_generation/news_rss.R
+++ b/_scripts/news_generation/news_rss.R
@@ -81,8 +81,13 @@ update_feeds <- function(feed_files,
   new_rss <- rss %>%
     anti_join(existing_rss, by = "rss_id")
 
-
+  # TODO: Should this refer to new_rss?
+  if ("item_enclosure" %in% colnames(rss)) {
+    rss$item_enclosure <- NULL
+  }
+  
   rss <- existing_rss %>%
+    # TODO: Should this refer to new_rss?
     rows_insert(rss, by = "rss_id", conflict = "ignore")
 
 

--- a/_scripts/news_generation/rss_feeds/rss_feeds_humboldt.txt
+++ b/_scripts/news_generation/rss_feeds/rss_feeds_humboldt.txt
@@ -1,5 +1,5 @@
-! https://humboldtgov.org/RSSFeed.aspx?ModID=65&CID=Fish-Game-Advisory-Commission-30 #not rss
-! https://humboldtgov.org/RSSFeed.aspx?ModID=65&CID=Headwaters-Fund-Board-28 #not rss
+https://humboldtgov.org/RSSFeed.aspx?ModID=65&CID=Fish-Game-Advisory-Commission-30
+https://humboldtgov.org/RSSFeed.aspx?ModID=65&CID=Headwaters-Fund-Board-28
 https://lostcoastoutpost.com/feed/
 https://humboldtwaterkeeper.org/news/latest?format=feed&type=rss
 https://humboldtwaterkeeper.org/offshore-wind-energy?format=feed&type=rss

--- a/_scripts/news_generation/rss_feeds/rss_feeds_santa_barbara.txt
+++ b/_scripts/news_generation/rss_feeds/rss_feeds_santa_barbara.txt
@@ -1,8 +1,8 @@
 keyt.com/feed
-! independent.com/feed # removed because columns don't match for `item_guid`
-! edhat.com/rss.xml #bad format
+independent.com/feed
+! edhat.com/rss.xml #not found
 ! newspress.com/feed #down on 3/11/24
-! https://feeds.bignewsnetwork.com/category/52a5b5547c5375f6
+https://feeds.bignewsnetwork.com/category/52a5b5547c5375f6
 ! https://losangeles.cbslocal.com/tag/santa-barbara/feed/ #not a feed
-! https://ktla.com/tag/santa-barbara-county/feed/ #bad format
+https://ktla.com/tag/santa-barbara-county/feed/
 https://www.noozhawk.com/feed/


### PR DESCRIPTION
# List of Changes

- I removed as many skipped (`!`) feeds as possible, checking only that `source("_scripts/news_generation/news_rss.R")` threw no errors. If the process needs to check something else, please let me know before we merge (in order to not introduce bugs).
- One of the feeds was introducing a new column (`item_enclosure`) which I decided to remove from the new dataset in order to be able to combine with the existing ones.
- I don't understand why when we run `rows_insert()` we reference `rss` instead of `new_rss`. Is there a reason for that? @bbest 